### PR TITLE
Migrate to new class syntax, fix visibility of shared variables

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -59,8 +59,8 @@ const TaskMain = new Lang.Class({
         this.icon = new St.Icon({icon_name: INDICATOR_ICON, icon_size : 18, style_class: 'system-status-icon'});
         this.icon.gicon = Gio.icon_new_for_string(Me.path + '/icons/' + INDICATOR_ICON + '.png')
         nbox.add_child(this.icon);
-        this.actor.add_child(nbox);
-        this.actor.show();
+        this.add_child(nbox);
+        this.show();
 
         // Bind menu opening to user defined keyboard shortcut
         this.add_keybindings();
@@ -69,7 +69,7 @@ const TaskMain = new Lang.Class({
 
         // Check taskwarrior is available on host and version is ok
         if (this._verifyTaskwarriorVersion(Taskwarrior.TASKWARRIOR_COMPAT)) {
-            this.actorId = this.actor.connect('button-press-event', Lang.bind(this, this._mainUi));
+            this.actorId = this.connect('button-press-event', Lang.bind(this, this._mainUi));
             // Get task list and build ui menu
             this._mainUi();
         }
@@ -152,7 +152,7 @@ const TaskMain = new Lang.Class({
             Schema.disconnect(this.keybindingChangedId);
         }
         if (this.actorId) {
-            this.actor.disconnect(this.actorId);
+            this.disconnect(this.actorId);
         }
         if (this.goToWebsiteId) {
             this.goToWebsite.disconnect(this.goToWebsiteId);

--- a/metadata.json
+++ b/metadata.json
@@ -4,4 +4,4 @@
   "settings-schema": "org.gnome.shell.extensions.taskwarrior-integration",
   "description": "Access Taskwarrior from the Gnome Shell",
   "url": "https://github.com/sgaraud/gnome-extension-taskwarrior",
-  "shell-version": ["3.14","3.16","3.18","3.20","3.22"]}
+  "shell-version": ["3.14","3.16","3.18","3.20","3.22","3.38"]}

--- a/prefs.js
+++ b/prefs.js
@@ -32,9 +32,9 @@ const Params = imports.misc.params;
 const Gettext = imports.gettext.domain('taskwarrior-integration');
 const _ = Gettext.gettext;
 
-const TOGGLE_MENU = 'toggle-menu';
-const DESC_LINE_LENGTH = 'max-task-description-line-length';
-const TAG_LINE_LENGTH = 'max-task-tags-line-length';
+var TOGGLE_MENU = 'toggle-menu';
+var DESC_LINE_LENGTH = 'max-task-description-line-length';
+var TAG_LINE_LENGTH = 'max-task-tags-line-length';
 let Schema = null;
 
 function init() {

--- a/taskwarrior.js
+++ b/taskwarrior.js
@@ -68,9 +68,8 @@ var taskwarriorCmds = {
     default: function () { printerr("unknown taskwarriorCmds"); }
 };
 
-const Task = new Lang.Class({
-    Name: 'Task',
-    _init: function (task) {
+class Task {
+    constructor(task) {
         this.uuid = task.uuid;
         this.id = task.id;
         this.description = task.description;
@@ -83,7 +82,7 @@ const Task = new Lang.Class({
         this.project = task.project;
         this.tags = task.tags;
     }
-});
+}
 
 /*
  * Function to export pending task list from Taskwarrior.

--- a/taskwarrior.js
+++ b/taskwarrior.js
@@ -29,31 +29,31 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
-const TASKWARRIOR_COMPAT = [2,3,0];
+var TASKWARRIOR_COMPAT = [2,3,0];
 
-const SP = " ";
-const TASK_WEBSITE = 'https://taskwarrior.org/download/';
-const TASK_BIN = 'task';
-const TASK_EXPORT = 'export';
-const TASK_ADD = 'add';
-const TASK_DONE = 'done';
-const TASK_DELETE = 'delete';
-const TASK_MODIFY = 'modify';
-const TASK_START = 'start';
-const TASK_STOP = 'stop';
-const TASK_VERSION = '--version';
-const TASK_STATUS_PENDING = 'status:pending';
-const TASK_NO_JSON_ARRAY = 'rc.json.array:off';
-const TASK_NO_CONFIRM = 'rc.confirmation:off';
-const TASK_ERROR = 1;
+var SP = " ";
+var TASK_WEBSITE = 'https://taskwarrior.org/download/';
+var TASK_BIN = 'task';
+var TASK_EXPORT = 'export';
+var TASK_ADD = 'add';
+var TASK_DONE = 'done';
+var TASK_DELETE = 'delete';
+var TASK_MODIFY = 'modify';
+var TASK_START = 'start';
+var TASK_STOP = 'stop';
+var TASK_VERSION = '--version';
+var TASK_STATUS_PENDING = 'status:pending';
+var TASK_NO_JSON_ARRAY = 'rc.json.array:off';
+var TASK_NO_CONFIRM = 'rc.confirmation:off';
+var TASK_ERROR = 1;
 
-const LABEL_EMPTY = "...";
-const LABEL_PROJECT = "project";
-const LABEL_PRIORITY = "priority";
-const LABEL_ENTERED = "created";
-const LABEL_START = "started";
-const LABEL_DUE = "due";
-const LABEL_TAGS = "tags";
+var LABEL_EMPTY = "...";
+var LABEL_PROJECT = "project";
+var LABEL_PRIORITY = "priority";
+var LABEL_ENTERED = "created";
+var LABEL_START = "started";
+var LABEL_DUE = "due";
+var LABEL_TAGS = "tags";
 
 /*
  * Dispatch table for possible cmd towards taskwarrior

--- a/taskwarrior.js
+++ b/taskwarrior.js
@@ -23,6 +23,7 @@
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 
+const ByteArray = imports.byteArray;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -92,7 +93,7 @@ function _exportTasks (filter) {
     try {
         //[ok: Boolean, standard_output: ByteArray, standard_error: ByteArray, exit_status: Number(gint)]
         let [res, out, err, status] = GLib.spawn_command_line_sync(TASK_BIN + SP + TASK_EXPORT + SP + filter);
-        let lines = out.toString().split('\n');
+        let lines = ByteArray.toString(out).split('\n');
 
         for (let i = 0; i < lines.length; i++) {
             // comma terminated in old taskwarrior versions
@@ -201,7 +202,7 @@ function _deleteTask(uuid) {
 function _getVersion() {
     try {
         let [res, out, err, status] = GLib.spawn_command_line_sync(TASK_BIN + SP + TASK_VERSION);
-        return out.toString().split('.');
+        return ByteArray.toString(out).split('.');
     } catch (err) {
         printerr(err);
         return TASK_ERROR;


### PR DESCRIPTION
This could help bring the extension into newer gnome versions. Unfortunately I could only test Arch linux' gnome-shell 3.38.

Only expanders in ui.js do not work yet.

Should fix #25, #22.